### PR TITLE
Update constructors

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -129,7 +129,7 @@ PATCHED_LEGACY_FACTORY_BIN=$(echo $LEGACY_FACTORY_BIN | sed -e "s.__TOKEN_ADDRES
 LEGACY_FACTORY_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA=$PATCHED_LEGACY_FACTORY_BIN GAS=3500000 eth_sendTransaction))
 echo deployed legacy factory to $LEGACY_FACTORY_ADDRESS >&2
 
-POSTAGE_STAMP_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${POSTAGE_STAMP_BIN}$(to_abi_address $TOKEN_ADDRESS)$(to_abi_hex 16 64)" GAS=3500000 eth_sendTransaction))
+POSTAGE_STAMP_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${POSTAGE_STAMP_BIN}$(to_abi_address $TOKEN_ADDRESS)$(to_abi_hex 16 64)$(to_abi_address $PRIMARY_ACCOUNT)" GAS=3500000 eth_sendTransaction))
 echo deployed postage stamp contract to $POSTAGE_STAMP_ADDRESS >&2
 
 SWAP_PRICE_ORACLE_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${SWAP_PRICE_ORACLE_BIN}$(to_abi_hex 100000 64)$(to_abi_hex 1 64)" GAS=3500000 eth_sendTransaction))

--- a/deploy.sh
+++ b/deploy.sh
@@ -139,13 +139,13 @@ PATCHED_FACTORY_BIN=$(echo $FACTORY_BIN | sed -e "s.__TOKEN_ADDRESS__.$(to_abi_a
 FACTORY_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA=$PATCHED_FACTORY_BIN GAS=3500000 eth_sendTransaction))
 echo deployed factory to $FACTORY_ADDRESS >&2
 
-INCENTIVES_PRICE_ORACLE_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${INCENTIVES_PRICE_ORACLE_BIN}$(to_abi_address $POSTAGE_STAMP_ADDRESS)$(to_abi_address $TOKEN_ADDRESS)" GAS=3500000 eth_sendTransaction))
+INCENTIVES_PRICE_ORACLE_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${INCENTIVES_PRICE_ORACLE_BIN}$(to_abi_address $POSTAGE_STAMP_ADDRESS)$(to_abi_address $PRIMARY_ACCOUNT)" GAS=3500000 eth_sendTransaction))
 echo deployed incentives price oracle contract to $INCENTIVES_PRICE_ORACLE_ADDRESS >&2
 
-STAKING_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${STAKING_BIN}$(to_abi_address $TOKEN_ADDRESS)$(to_abi_hex 12345 64)" GAS=3500000 eth_sendTransaction))
+STAKING_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${STAKING_BIN}$(to_abi_address $TOKEN_ADDRESS)$(to_abi_hex 12345 64)$(to_abi_address $PRIMARY_ACCOUNT)" GAS=3500000 eth_sendTransaction))
 echo deployed staking contract to $STAKING_ADDRESS >&2
 
-REDISTRIBUTION_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${REDISTRIBUTION_BIN}$(to_abi_address $STAKING_ADDRESS)$(to_abi_address $POSTAGE_STAMP_ADDRESS)$(to_abi_address $INCENTIVES_PRICE_ORACLE_ADDRESS)" GAS=3500000 eth_sendTransaction))
+REDISTRIBUTION_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${REDISTRIBUTION_BIN}$(to_abi_address $STAKING_ADDRESS)$(to_abi_address $POSTAGE_STAMP_ADDRESS)$(to_abi_address $INCENTIVES_PRICE_ORACLE_ADDRESS)$(to_abi_address $PRIMARY_ACCOUNT)" GAS=3500000 eth_sendTransaction))
 echo deployed redistribution contract to $REDISTRIBUTION_ADDRESS >&2
 
 grantPriceOracleRole $POSTAGE_STAMP_ADDRESS $PRIMARY_ACCOUNT > /dev/null &

--- a/deploy.sh
+++ b/deploy.sh
@@ -139,7 +139,7 @@ PATCHED_FACTORY_BIN=$(echo $FACTORY_BIN | sed -e "s.__TOKEN_ADDRESS__.$(to_abi_a
 FACTORY_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA=$PATCHED_FACTORY_BIN GAS=3500000 eth_sendTransaction))
 echo deployed factory to $FACTORY_ADDRESS >&2
 
-INCENTIVES_PRICE_ORACLE_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${INCENTIVES_PRICE_ORACLE_BIN}$(to_abi_address $POSTAGE_STAMP_ADDRESS)" GAS=3500000 eth_sendTransaction))
+INCENTIVES_PRICE_ORACLE_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${INCENTIVES_PRICE_ORACLE_BIN}$(to_abi_address $POSTAGE_STAMP_ADDRESS)$(to_abi_address $TOKEN_ADDRESS)" GAS=3500000 eth_sendTransaction))
 echo deployed incentives price oracle contract to $INCENTIVES_PRICE_ORACLE_ADDRESS >&2
 
 STAKING_ADDRESS=$(wait_for_deploy $(FROM=$PRIMARY_ACCOUNT DATA="${STAKING_BIN}$(to_abi_address $TOKEN_ADDRESS)$(to_abi_hex 12345 64)" GAS=3500000 eth_sendTransaction))


### PR DESCRIPTION
current contracts all have in constructor extra parametar that is multisig wallet inserted as owner of contracts, but for local and test deployments we can just use plain deployer for that role.  this was missing in .sh script